### PR TITLE
Bugfix

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
-export const baseUrl = "https://ulti-mate.herokuapp.com";
+export const baseUrl = "http://localhost:4000";
 
 // local: http://localhost:4000
 //https://ulti-mate.herokuapp.com

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
-export const baseUrl = "http://localhost:4000";
+export const baseUrl = "https://ulti-mate.herokuapp.com";
 
 // local: http://localhost:4000
 //https://ulti-mate.herokuapp.com

--- a/src/store/game/actions.js
+++ b/src/store/game/actions.js
@@ -19,7 +19,7 @@ export function updateSpiritScore(spiritScoreData, id) {
       );
       console.log("Game with updated spirit", gameWithUpdatedSpirit);
       dispatch(updateGameDetailsAction(gameWithUpdatedSpirit.data));
-      dispatch(setGameDetailsAction(gameWithUpdatedSpirit.data));
+      dispatch(setGameDetailsAction(gameWithUpdatedSpirit.data.updatedGame));
       dispatch(setNewStatusAction(gameWithUpdatedSpirit));
     } catch (error) {
       dispatch(setNewStatusAction(error.response));


### PR DESCRIPTION
Upon updating a spirit score, the data that was sent to the store wasn't correctly entered. The subobject "updatedGame" wasn't sent, but the entire object. Therefore, the components couldn't read the actual relevant data. This has been fixed by changing the part of the response that gets sent to the store.

Forgot to revert the api URL back to the online one on heroku. Therefore, the previous pull request was closed without merging. 