### PR TITLE
make sure add new spirit score will be true in the right situations

### DIFF
--- a/src/components/Scores/SpiritScoreForm.jsx
+++ b/src/components/Scores/SpiritScoreForm.jsx
@@ -86,7 +86,8 @@ export class SpiritScoreForm extends Component {
     } = this.props;
 
     const addNewSpiritScore =
-      homeTeamReceivedSpiritScoreId || awayTeamReceivedSpiritScoreId
+      (spiritScoreFor === "home" && homeTeamReceivedSpiritScoreId) ||
+      (spiritScoreFor === "away" && awayTeamReceivedSpiritScoreId)
         ? false
         : true;
 


### PR DESCRIPTION
There was an error because if either of the spirit scores were filled in, the client would send an update request to the the backend. However, this did not work if one spirit score had been filled in. It would try to update the non-filled in spirit score, which would not be possible and throw a database error. 