### PR TITLE
fix issue where an empty payload blocks store change

### DIFF
--- a/src/store/status/reducer.js
+++ b/src/store/status/reducer.js
@@ -8,6 +8,7 @@ const initialState = {
 export default (state = initialState, { type, payload }) => {
   switch (type) {
     case SET_NEW_STATUS: {
+      if (!payload) return state;
       return {
         ...state,
         code: payload.status,


### PR DESCRIPTION
This fix actually does not tackle the deeper issue, but it does solve the bug that presented itself. 

The reducer gets called twice, but on the second round it is empty. Added a check to return the state if the payload is empty. 